### PR TITLE
Fix issue where non us-east-1 regions will not read queue. 

### DIFF
--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -10,7 +10,12 @@ defmodule SQSBroadway do
     Broadway.start_link(__MODULE__,
       name: __MODULE__,
       producer: [
-        module: {BroadwaySQS.Producer, queue_url: sqs_url}
+        module:
+          {BroadwaySQS.Producer,
+           queue_url: sqs_url,
+           config: [
+             region: System.get_env("AWS_REGION")
+           ]}
       ],
       processors: [
         default: [concurrency: 50]


### PR DESCRIPTION
broadway says it uses the region in exaws but that seems to not be true. Just pass it in explicitly.